### PR TITLE
Add CLI and workbook tooling scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "auto-movie-edit"
+version = "0.1.0"
+description = "Tools for generating YMM4-compatible projects from spreadsheet timelines."
+authors = [{name = "Auto Generated", email = "auto@example.com"}]
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "openpyxl>=3.1.2",
+    "typer>=0.9.0",
+]
+
+[project.scripts]
+auto-movie-edit = "auto_movie_edit.cli:app"
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/src/auto_movie_edit/__init__.py
+++ b/src/auto_movie_edit/__init__.py
@@ -1,0 +1,5 @@
+"""Utility package for converting spreadsheet timelines into YMM4-compatible projects."""
+
+from .cli import app
+
+__all__ = ["app"]

--- a/src/auto_movie_edit/cli.py
+++ b/src/auto_movie_edit/cli.py
@@ -1,0 +1,169 @@
+"""Command line interface for the auto_movie_edit toolkit."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable, Optional
+
+import typer
+from openpyxl import load_workbook
+
+from .srt import SrtParseError, parse_srt
+from .workbook import (
+    DEFAULT_TEMPLATE,
+    create_workbook_template,
+    load_workbook_data,
+    save_workbook,
+)
+from .ymmp import apply_hiragana_shrink, build_project, write_outputs
+
+app = typer.Typer(help="Auto Movie Edit CLI utilities")
+
+
+@app.command("make-sheet")
+def make_sheet(
+    srt: Path = typer.Option(..., exists=True, dir_okay=False, readable=True, help="SRT subtitle file"),
+    out: Path = typer.Option(..., dir_okay=False, help="Output Excel file"),
+) -> None:
+    """Create a workbook template populated with SRT subtitles."""
+
+    try:
+        entries = parse_srt(srt)
+    except SrtParseError as exc:
+        typer.secho(str(exc), fg=typer.colors.RED)
+        raise typer.Exit(code=1) from exc
+
+    workbook = create_workbook_template(DEFAULT_TEMPLATE)
+    timeline_sheet = workbook["TIMELINE"]
+
+    for row_index, entry in enumerate(entries, start=2):
+        timeline_sheet.cell(row=row_index, column=1, value=entry.start.to_string())
+        timeline_sheet.cell(row=row_index, column=2, value=entry.end.to_string())
+        timeline_sheet.cell(row=row_index, column=3, value=entry.text)
+
+    save_workbook(workbook, out)
+    typer.secho(f"Workbook created: {out}", fg=typer.colors.GREEN)
+
+
+@app.command("build")
+def build(
+    sheet: Path = typer.Option(..., exists=True, dir_okay=False, readable=True, help="Timeline workbook"),
+    out: Path = typer.Option(Path("work"), file_okay=False, dir_okay=True, help="Output directory"),
+) -> None:
+    """Build a simplified YMMP project from the workbook."""
+
+    data = load_workbook_data(sheet)
+    project, warnings = build_project(data)
+    write_outputs(project, warnings, out)
+    typer.secho(f"Project generated with {len(warnings)} warnings -> {out}", fg=typer.colors.GREEN)
+
+
+@app.command("filter")
+def filter_command(
+    filter_name: str = typer.Argument(..., help="Filter name"),
+    input_path: Path = typer.Option(..., exists=True, dir_okay=False, help="Input YMMP JSON"),
+    out: Path = typer.Option(..., dir_okay=False, help="Output YMMP JSON"),
+    scale: Optional[float] = typer.Option(0.85, help="Scale applied to telop text"),
+) -> None:
+    """Apply post-processing filters to a project."""
+
+    filter_name = filter_name.lower()
+    if filter_name == "hira-shrink":
+        apply_hiragana_shrink(input_path, out, scale or 0.85)
+        typer.secho(f"Hiragana shrink applied -> {out}", fg=typer.colors.GREEN)
+    else:
+        typer.secho(f"Unknown filter: {filter_name}", fg=typer.colors.RED)
+        raise typer.Exit(code=1)
+
+
+@app.command("absorb")
+def absorb(
+    ymmp: Path = typer.Option(..., exists=True, dir_okay=False, readable=True, help="Source YMMP JSON"),
+    xlsx: Path = typer.Option(..., dir_okay=False, help="Workbook to update"),
+) -> None:
+    """Absorb a YMMP file into the workbook dictionaries."""
+
+    project = json.loads(ymmp.read_text(encoding="utf-8"))
+
+    if xlsx.exists():
+        workbook = load_workbook(xlsx)
+    else:
+        workbook = create_workbook_template(DEFAULT_TEMPLATE)
+
+    _sync_dictionary_sheet(workbook, "TELP_PATTERNS", DEFAULT_TEMPLATE.telp_headers, project.get("telop_patterns", {}))
+    _sync_dictionary_sheet(workbook, "ASSETS_SINGLE", DEFAULT_TEMPLATE.asset_headers, project.get("assets", {}))
+    _sync_dictionary_sheet(workbook, "PACKS_MULTI", DEFAULT_TEMPLATE.pack_headers, project.get("packs", {}))
+    _sync_dictionary_sheet(workbook, "FX", DEFAULT_TEMPLATE.fx_headers, project.get("fx_presets", {}))
+    _sync_dictionary_sheet(workbook, "LAYERS", DEFAULT_TEMPLATE.layer_headers, project.get("layers", {}))
+
+    save_workbook(workbook, xlsx)
+    typer.secho(f"Workbook updated with project dictionaries -> {xlsx}", fg=typer.colors.GREEN)
+
+
+def _sync_dictionary_sheet(workbook, name: str, headers: Iterable[str], values: dict) -> None:
+    header_list = list(headers)
+    if name in workbook.sheetnames:
+        sheet = workbook[name]
+        if sheet.max_row < 1:
+            _write_headers(sheet, header_list)
+    else:
+        sheet = workbook.create_sheet(name)
+        _write_headers(sheet, header_list)
+
+    existing_ids = set()
+    id_column = 1
+    for row_index in range(2, sheet.max_row + 1):
+        value = sheet.cell(row=row_index, column=id_column).value
+        if value:
+            existing_ids.add(str(value))
+
+    for key, payload in values.items():
+        identifier = str(key)
+        if identifier in existing_ids:
+            continue
+        row_index = sheet.max_row + 1
+        sheet.cell(row=row_index, column=1, value=identifier)
+        for column, header in enumerate(header_list[1:], start=2):
+            if isinstance(payload, dict):
+                cell_value = payload.get(_map_field_name(header))
+            else:
+                cell_value = None
+            if isinstance(cell_value, (dict, list)):
+                cell_value = json.dumps(cell_value, ensure_ascii=False)
+            sheet.cell(row=row_index, column=column, value=cell_value)
+        existing_ids.add(identifier)
+
+
+def _write_headers(sheet, headers: Iterable[str]) -> None:
+    for column, header in enumerate(headers, start=1):
+        sheet.cell(row=1, column=column, value=header)
+
+
+def _map_field_name(header: str) -> str:
+    mapping = {
+        "参照ソース": "source",
+        "上書きキー": "overrides",
+        "基準幅": "base_width",
+        "基準高さ": "base_height",
+        "FPS": "fps",
+        "説明": "description",
+        "備考": "notes",
+        "種別": "kind",
+        "パス": "path",
+        "既定レイヤ": "default_layer",
+        "既定X": "default_x",
+        "既定Y": "default_y",
+        "既定ズーム": "default_zoom",
+        "役割": "role",
+        "レイヤ帯": "layer",
+        "種類": "fx_type",
+        "パック": "source",
+        "アセット": "asset",
+        "パラメータ": "parameters",
+    }
+    return mapping.get(header, header)
+
+
+if __name__ == "__main__":
+    app()

--- a/src/auto_movie_edit/models.py
+++ b/src/auto_movie_edit/models.py
@@ -1,0 +1,115 @@
+"""Data models representing spreadsheet concepts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from .utils import Timecode
+
+
+@dataclass(slots=True)
+class TelopPattern:
+    """Represents a telop (caption) pattern definition."""
+
+    pattern_id: str
+    source: Optional[str] = None
+    overrides: Dict[str, Any] = field(default_factory=dict)
+    base_width: Optional[int] = None
+    base_height: Optional[int] = None
+    fps: Optional[float] = None
+    description: Optional[str] = None
+    notes: Optional[str] = None
+
+
+@dataclass(slots=True)
+class Asset:
+    """Represents a single asset (image, audio, etc.)."""
+
+    asset_id: str
+    kind: Optional[str] = None
+    path: Optional[str] = None
+    default_layer: Optional[int] = None
+    default_x: Optional[float] = None
+    default_y: Optional[float] = None
+    default_zoom: Optional[float] = None
+    notes: Optional[str] = None
+
+
+@dataclass(slots=True)
+class Pack:
+    """Represents a multi-object pack definition."""
+
+    pack_id: str
+    source: Optional[str] = None
+    overrides: Dict[str, Any] = field(default_factory=dict)
+    base_width: Optional[int] = None
+    base_height: Optional[int] = None
+    fps: Optional[float] = None
+    notes: Optional[str] = None
+
+
+@dataclass(slots=True)
+class LayerBand:
+    """Represents mapping from a role to a layer band."""
+
+    role: str
+    layer: int
+
+
+@dataclass(slots=True)
+class FxPreset:
+    """Represents an FX preset definition referenced from the timeline."""
+
+    fx_id: str
+    fx_type: Optional[str] = None
+    source: Optional[str] = None
+    asset: Optional[str] = None
+    parameters: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class TimelineObject:
+    """Represents a single timeline object entry."""
+
+    role: str
+    identifier: str
+    layer: Optional[int]
+    resolved: Optional[Asset | Pack | TelopPattern] = None
+
+
+@dataclass(slots=True)
+class TimelineFx:
+    """Represents FX applied to a timeline row."""
+
+    fx_id: str
+    parameters: Dict[str, Any] = field(default_factory=dict)
+    resolved: Optional[FxPreset] = None
+
+
+@dataclass(slots=True)
+class TimelineRow:
+    """Represents a single TIMELINE row from the spreadsheet."""
+
+    index: int
+    start: Optional[Timecode]
+    end: Optional[Timecode]
+    subtitle: Optional[str]
+    telop: Optional[str]
+    packs: List[str] = field(default_factory=list)
+    objects: List[TimelineObject] = field(default_factory=list)
+    fxs: List[TimelineFx] = field(default_factory=list)
+    notes: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class WorkbookData:
+    """Container for all information extracted from the workbook."""
+
+    telop_patterns: Dict[str, TelopPattern] = field(default_factory=dict)
+    assets: Dict[str, Asset] = field(default_factory=dict)
+    packs: Dict[str, Pack] = field(default_factory=dict)
+    layers: Dict[str, LayerBand] = field(default_factory=dict)
+    fx_presets: Dict[str, FxPreset] = field(default_factory=dict)
+    timeline: List[TimelineRow] = field(default_factory=list)
+    schema_map: Dict[str, Dict[str, str]] = field(default_factory=dict)

--- a/src/auto_movie_edit/srt.py
+++ b/src/auto_movie_edit/srt.py
@@ -1,0 +1,72 @@
+"""SRT (SubRip) subtitle parser used for timeline scaffolding."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Iterator, List
+
+from .utils import Timecode, TimecodeError, parse_timecode
+
+
+@dataclass(slots=True)
+class SrtEntry:
+    """Represents a single SRT subtitle block."""
+
+    index: int
+    start: Timecode
+    end: Timecode
+    text: str
+
+
+class SrtParseError(RuntimeError):
+    """Raised when an SRT file cannot be parsed."""
+
+
+def _chunks(lines: Iterable[str]) -> Iterator[list[str]]:
+    chunk: list[str] = []
+    for line in lines:
+        stripped = line.rstrip("\n")
+        if stripped == "":
+            if chunk:
+                yield chunk
+                chunk = []
+            continue
+        chunk.append(stripped)
+    if chunk:
+        yield chunk
+
+
+def parse_srt(path: str | Path) -> List[SrtEntry]:
+    """Parse an SRT file and return a list of entries."""
+
+    path = Path(path)
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise SrtParseError(f"SRT file not found: {path}") from exc
+
+    entries: list[SrtEntry] = []
+    for raw_chunk in _chunks(text.splitlines()):
+        if not raw_chunk:
+            continue
+        try:
+            index = int(raw_chunk[0])
+        except ValueError as exc:
+            raise SrtParseError(f"Invalid SRT index line: {raw_chunk[0]!r}") from exc
+        if len(raw_chunk) < 2:
+            raise SrtParseError(f"Missing timecode line for index {index}")
+        times = raw_chunk[1]
+        if "-->" not in times:
+            raise SrtParseError(f"Invalid timecode line for index {index}: {times!r}")
+        start_text, end_text = [part.strip() for part in times.split("-->")]
+        try:
+            start = parse_timecode(start_text)
+            end = parse_timecode(end_text)
+        except TimecodeError as exc:
+            raise SrtParseError(str(exc)) from exc
+        if start is None or end is None:
+            raise SrtParseError(f"Incomplete timecode for index {index}")
+        text_lines = raw_chunk[2:]
+        entries.append(SrtEntry(index=index, start=start, end=end, text="\n".join(text_lines)))
+    return entries

--- a/src/auto_movie_edit/utils.py
+++ b/src/auto_movie_edit/utils.py
@@ -1,0 +1,179 @@
+"""Shared utility helpers for the auto_movie_edit package."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Any, Dict, Iterable, Optional
+
+_TIME_PATTERN = re.compile(
+    r"^(?P<hour>\d{2}):(?P<minute>\d{2}):(?P<second>\d{2})(?:\.(?P<millis>\d{1,3}))?$"
+)
+
+
+class TimecodeError(ValueError):
+    """Raised when a timecode string cannot be parsed."""
+
+
+@dataclass(slots=True)
+class Timecode:
+    """Represents a parsed timecode."""
+
+    hours: int
+    minutes: int
+    seconds: int
+    milliseconds: int = 0
+
+    def to_timedelta(self) -> timedelta:
+        """Convert the timecode into :class:`datetime.timedelta`."""
+
+        return timedelta(
+            hours=self.hours,
+            minutes=self.minutes,
+            seconds=self.seconds,
+            milliseconds=self.milliseconds,
+        )
+
+    def to_seconds(self) -> float:
+        """Return the total seconds represented by the timecode."""
+
+        td = self.to_timedelta()
+        return td.total_seconds()
+
+    def to_string(self) -> str:
+        """Render the timecode as ``HH:MM:SS.mmm`` string."""
+
+        return f"{self.hours:02d}:{self.minutes:02d}:{self.seconds:02d}.{self.milliseconds:03d}"
+
+
+def parse_timecode(value: str | None) -> Optional[Timecode]:
+    """Parse a timecode string into a :class:`Timecode` instance.
+
+    Args:
+        value: The string value to parse. ``None`` or an empty string returns ``None``.
+
+    Raises:
+        TimecodeError: If the value cannot be parsed as a timecode.
+    """
+
+    if value is None:
+        return None
+
+    value = value.strip()
+    if not value:
+        return None
+
+    match = _TIME_PATTERN.match(value)
+    if not match:
+        raise TimecodeError(f"Invalid timecode: {value!r}")
+
+    millis = match.group("millis")
+    milliseconds = int(millis) if millis else 0
+    return Timecode(
+        hours=int(match.group("hour")),
+        minutes=int(match.group("minute")),
+        seconds=int(match.group("second")),
+        milliseconds=milliseconds,
+    )
+
+
+def parse_mapping(raw: Any) -> Dict[str, Any]:
+    """Parse a mapping definition stored as JSON or semi-colon separated pairs.
+
+    Args:
+        raw: The raw value, typically a string stored in a spreadsheet cell.
+
+    Returns:
+        A dictionary representing the mapping. Unknown formats yield an empty dict.
+    """
+
+    if raw is None:
+        return {}
+
+    if isinstance(raw, dict):
+        return dict(raw)
+
+    if isinstance(raw, str):
+        text = raw.strip()
+        if not text:
+            return {}
+
+        # Try JSON first.
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError:
+            pairs: Dict[str, Any] = {}
+            for chunk in text.split(";"):
+                chunk = chunk.strip()
+                if not chunk or "=" not in chunk:
+                    continue
+                key, value = chunk.split("=", 1)
+                pairs[key.strip()] = value.strip()
+            return pairs
+        else:
+            if isinstance(parsed, dict):
+                return parsed
+            return {}
+
+    return {}
+
+
+def ensure_list(value: Any) -> list[Any]:
+    """Ensure a value is returned as a list, splitting comma separated strings."""
+
+    if value is None:
+        return []
+
+    if isinstance(value, list):
+        return value
+
+    if isinstance(value, tuple):
+        return list(value)
+
+    if isinstance(value, str):
+        chunks = [chunk.strip() for chunk in value.split(",")]
+        return [chunk for chunk in chunks if chunk]
+
+    return [value]
+
+
+def load_json(path: str | "os.PathLike[str]") -> Any:
+    """Load a JSON document from ``path``."""
+
+    with open(path, "r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def dump_json(path: str | "os.PathLike[str]", data: Any) -> None:
+    """Write a JSON document to ``path`` with UTF-8 encoding."""
+
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, ensure_ascii=False, indent=2)
+
+
+def iter_nonempty(rows: Iterable[dict[str, Any]]) -> Iterable[dict[str, Any]]:
+    """Yield only rows that contain at least one non-empty value."""
+
+    for row in rows:
+        if not row:
+            continue
+        for value in row.values():
+            if value not in (None, ""):
+                yield row
+                break
+
+
+def count_hiragana(text: str) -> int:
+    """Count the number of Hiragana characters in ``text``."""
+
+    return sum(1 for char in text if "\u3040" <= char <= "\u309f")
+
+
+def contains_hiragana(text: str | None) -> bool:
+    """Return ``True`` if the given text contains at least one Hiragana character."""
+
+    if not text:
+        return False
+    return count_hiragana(text) > 0

--- a/src/auto_movie_edit/workbook.py
+++ b/src/auto_movie_edit/workbook.py
@@ -1,0 +1,354 @@
+"""Functions for reading and writing workbook files used by the pipeline."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+
+from openpyxl import Workbook, load_workbook
+
+from .models import (
+    Asset,
+    FxPreset,
+    LayerBand,
+    Pack,
+    TelopPattern,
+    TimelineFx,
+    TimelineObject,
+    TimelineRow,
+    WorkbookData,
+)
+from .utils import ensure_list, iter_nonempty, parse_mapping, parse_timecode
+
+
+TELP_HEADERS = [
+    "パターンID",
+    "参照ソース",
+    "上書きキー",
+    "基準幅",
+    "基準高さ",
+    "FPS",
+    "説明",
+    "備考",
+]
+
+ASSET_HEADERS = [
+    "素材ID",
+    "種別",
+    "パス",
+    "既定レイヤ",
+    "既定X",
+    "既定Y",
+    "既定ズーム",
+    "備考",
+]
+
+PACK_HEADERS = [
+    "パックID",
+    "参照ソース",
+    "上書きキー",
+    "基準幅",
+    "基準高さ",
+    "FPS",
+    "備考",
+]
+
+LAYER_HEADERS = [
+    "役割",
+    "レイヤ帯",
+]
+
+FX_HEADERS = [
+    "FX_ID",
+    "種類",
+    "パック",
+    "アセット",
+    "パラメータ",
+]
+
+TIMELINE_HEADERS = [
+    "開始",
+    "終了",
+    "字幕テキスト",
+    "テロップ",
+    "パック",
+    "オブジェクト1",
+    "オブジェクト2",
+    "オブジェクト3",
+    "背景",
+    "FX_PARAM",
+    "承認",
+    "メモ",
+]
+
+SCHEMA_HEADERS = [
+    "シート",
+    "日本語",
+    "キー",
+]
+
+
+@dataclass(slots=True)
+class WorkbookTemplate:
+    """Represents the workbook template structure."""
+
+    telp_headers: List[str] = None
+    asset_headers: List[str] = None
+    pack_headers: List[str] = None
+    layer_headers: List[str] = None
+    fx_headers: List[str] = None
+    timeline_headers: List[str] = None
+    schema_headers: List[str] = None
+
+
+DEFAULT_TEMPLATE = WorkbookTemplate(
+    telp_headers=TELP_HEADERS,
+    asset_headers=ASSET_HEADERS,
+    pack_headers=PACK_HEADERS,
+    layer_headers=LAYER_HEADERS,
+    fx_headers=FX_HEADERS,
+    timeline_headers=TIMELINE_HEADERS,
+    schema_headers=SCHEMA_HEADERS,
+)
+
+
+def _write_headers(sheet, headers: Iterable[str]) -> None:
+    for col, header in enumerate(headers, start=1):
+        sheet.cell(row=1, column=col, value=header)
+
+
+def create_workbook_template(template: WorkbookTemplate = DEFAULT_TEMPLATE) -> Workbook:
+    """Create a workbook according to the template structure."""
+
+    wb = Workbook()
+    wb.remove(wb.active)
+
+    telp_sheet = wb.create_sheet("TELP_PATTERNS")
+    _write_headers(telp_sheet, template.telp_headers)
+
+    asset_sheet = wb.create_sheet("ASSETS_SINGLE")
+    _write_headers(asset_sheet, template.asset_headers)
+
+    pack_sheet = wb.create_sheet("PACKS_MULTI")
+    _write_headers(pack_sheet, template.pack_headers)
+
+    layer_sheet = wb.create_sheet("LAYERS")
+    _write_headers(layer_sheet, template.layer_headers)
+
+    fx_sheet = wb.create_sheet("FX")
+    _write_headers(fx_sheet, template.fx_headers)
+
+    timeline_sheet = wb.create_sheet("TIMELINE")
+    _write_headers(timeline_sheet, template.timeline_headers)
+
+    schema_sheet = wb.create_sheet("SCHEMA_MAP")
+    _write_headers(schema_sheet, template.schema_headers)
+
+    return wb
+
+
+def save_workbook(workbook: Workbook, path: str | Path) -> None:
+    """Persist the provided workbook to disk."""
+
+    path = Path(path)
+    workbook.save(path)
+
+
+def load_sheet_dictionaries(sheet) -> list[dict[str, Any]]:
+    """Load a worksheet into a list of dictionaries keyed by header."""
+
+    headers: list[str] = []
+    for cell in sheet[1]:
+        headers.append((cell.value or "").strip())
+    rows: list[dict[str, Any]] = []
+    for row in sheet.iter_rows(min_row=2, values_only=True):
+        record = {}
+        for index, header in enumerate(headers):
+            if not header:
+                continue
+            record[header] = row[index]
+        rows.append(record)
+    return rows
+
+
+def load_workbook_data(path: str | Path) -> WorkbookData:
+    """Load workbook data into strongly typed models."""
+
+    path = Path(path)
+    wb = load_workbook(path, data_only=True)
+
+    data = WorkbookData()
+
+    if "TELP_PATTERNS" in wb.sheetnames:
+        for record in iter_nonempty(load_sheet_dictionaries(wb["TELP_PATTERNS"])):
+            pattern_id = str(record.get("パターンID") or "").strip()
+            if not pattern_id:
+                continue
+            data.telop_patterns[pattern_id] = TelopPattern(
+                pattern_id=pattern_id,
+                source=record.get("参照ソース"),
+                overrides=parse_mapping(record.get("上書きキー")),
+                base_width=_safe_int(record.get("基準幅")),
+                base_height=_safe_int(record.get("基準高さ")),
+                fps=_safe_float(record.get("FPS")),
+                description=record.get("説明"),
+                notes=record.get("備考"),
+            )
+
+    if "ASSETS_SINGLE" in wb.sheetnames:
+        for record in iter_nonempty(load_sheet_dictionaries(wb["ASSETS_SINGLE"])):
+            asset_id = str(record.get("素材ID") or "").strip()
+            if not asset_id:
+                continue
+            data.assets[asset_id] = Asset(
+                asset_id=asset_id,
+                kind=record.get("種別"),
+                path=record.get("パス"),
+                default_layer=_safe_int(record.get("既定レイヤ")),
+                default_x=_safe_float(record.get("既定X")),
+                default_y=_safe_float(record.get("既定Y")),
+                default_zoom=_safe_float(record.get("既定ズーム")),
+                notes=record.get("備考"),
+            )
+
+    if "PACKS_MULTI" in wb.sheetnames:
+        for record in iter_nonempty(load_sheet_dictionaries(wb["PACKS_MULTI"])):
+            pack_id = str(record.get("パックID") or "").strip()
+            if not pack_id:
+                continue
+            data.packs[pack_id] = Pack(
+                pack_id=pack_id,
+                source=record.get("参照ソース"),
+                overrides=parse_mapping(record.get("上書きキー")),
+                base_width=_safe_int(record.get("基準幅")),
+                base_height=_safe_int(record.get("基準高さ")),
+                fps=_safe_float(record.get("FPS")),
+                notes=record.get("備考"),
+            )
+
+    if "LAYERS" in wb.sheetnames:
+        for record in iter_nonempty(load_sheet_dictionaries(wb["LAYERS"])):
+            role = str(record.get("役割") or "").strip()
+            if not role:
+                continue
+            layer_value = _safe_int(record.get("レイヤ帯"))
+            if layer_value is None:
+                continue
+            data.layers[role] = LayerBand(role=role, layer=layer_value)
+
+    if "FX" in wb.sheetnames:
+        for record in iter_nonempty(load_sheet_dictionaries(wb["FX"])):
+            fx_id = str(record.get("FX_ID") or "").strip()
+            if not fx_id:
+                continue
+            data.fx_presets[fx_id] = FxPreset(
+                fx_id=fx_id,
+                fx_type=record.get("種類"),
+                source=record.get("パック"),
+                asset=record.get("アセット"),
+                parameters=parse_mapping(record.get("パラメータ")),
+            )
+
+    if "SCHEMA_MAP" in wb.sheetnames:
+        schema_records = load_sheet_dictionaries(wb["SCHEMA_MAP"])
+        grouped: Dict[str, Dict[str, str]] = defaultdict(dict)
+        for record in iter_nonempty(schema_records):
+            sheet_name = str(record.get("シート") or "").strip()
+            if not sheet_name:
+                continue
+            japanese = str(record.get("日本語") or "").strip()
+            key = str(record.get("キー") or "").strip()
+            if japanese and key:
+                grouped[sheet_name][japanese] = key
+        data.schema_map = dict(grouped)
+
+    if "TIMELINE" in wb.sheetnames:
+        timeline_records = load_sheet_dictionaries(wb["TIMELINE"])
+        fx_param_key = "FX_PARAM"
+        fx_columns = [header for header in timeline_records[0].keys() if header.startswith("FX_")] if timeline_records else []
+        object_columns = [
+            header
+            for header in timeline_records[0].keys()
+            if header.startswith("オブジェクト") or header == "背景"
+        ] if timeline_records else []
+
+        for index, record in enumerate(iter_nonempty(timeline_records), start=1):
+            start = parse_timecode(_string_or_none(record.get("開始")))
+            end = parse_timecode(_string_or_none(record.get("終了")))
+            subtitle = _string_or_none(record.get("字幕テキスト"))
+            telop = _string_or_none(record.get("テロップ"))
+            packs = ensure_list(record.get("パック"))
+            timeline_objects: list[TimelineObject] = []
+            for column in object_columns:
+                identifier = _string_or_none(record.get(column))
+                if not identifier:
+                    continue
+                role = column
+                layer_band = data.layers.get(role)
+                layer = layer_band.layer if layer_band else None
+                resolved = data.assets.get(identifier)
+                timeline_objects.append(
+                    TimelineObject(role=role, identifier=identifier, layer=layer, resolved=resolved)
+                )
+            timeline_fxs: list[TimelineFx] = []
+            for column in fx_columns:
+                fx_identifier = _string_or_none(record.get(column))
+                if not fx_identifier:
+                    continue
+                resolved = data.fx_presets.get(fx_identifier)
+                params = {}
+                fx_param_value = record.get(fx_param_key)
+                if isinstance(fx_param_value, str):
+                    params = parse_mapping(fx_param_value)
+                timeline_fxs.append(TimelineFx(fx_id=fx_identifier, parameters=params, resolved=resolved))
+            notes = {key: value for key, value in record.items() if key not in {
+                "開始",
+                "終了",
+                "字幕テキスト",
+                "テロップ",
+                "パック",
+            }.union(object_columns, fx_columns, {fx_param_key})}
+            data.timeline.append(
+                TimelineRow(
+                    index=index,
+                    start=start,
+                    end=end,
+                    subtitle=subtitle,
+                    telop=telop,
+                    packs=packs,
+                    objects=timeline_objects,
+                    fxs=timeline_fxs,
+                    notes=notes,
+                )
+            )
+
+    return data
+
+
+def _safe_int(value: Any) -> int | None:
+    try:
+        if value is None or value == "":
+            return None
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _safe_float(value: Any) -> float | None:
+    try:
+        if value is None or value == "":
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _string_or_none(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        text = value.strip()
+        return text or None
+    return str(value)

--- a/src/auto_movie_edit/ymmp.py
+++ b/src/auto_movie_edit/ymmp.py
@@ -1,0 +1,168 @@
+"""Generation of simplified YMM4 project structures."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+from .models import TimelineRow, WorkbookData
+from .utils import contains_hiragana, dump_json
+
+
+class BuildWarning:
+    """Represents a warning produced during project build."""
+
+    def __init__(self, row_index: int | None, message: str) -> None:
+        self.row_index = row_index
+        self.message = message
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"row": self.row_index, "message": self.message}
+
+
+class ProjectBuilder:
+    """Transforms workbook data into a serialisable project representation."""
+
+    def __init__(self, data: WorkbookData) -> None:
+        self.data = data
+        self.warnings: list[BuildWarning] = []
+
+    def build(self) -> dict[str, Any]:
+        timeline_entries: list[dict[str, Any]] = []
+        for row in self.data.timeline:
+            entry = self._build_row(row)
+            timeline_entries.append(entry)
+        return {
+            "generated_at": datetime.utcnow().isoformat(timespec="seconds") + "Z",
+            "telop_patterns": {key: asdict(value) for key, value in self.data.telop_patterns.items()},
+            "assets": {key: asdict(value) for key, value in self.data.assets.items()},
+            "packs": {key: asdict(value) for key, value in self.data.packs.items()},
+            "fx_presets": {key: asdict(value) for key, value in self.data.fx_presets.items()},
+            "layers": {key: asdict(value) for key, value in self.data.layers.items()},
+            "timeline": timeline_entries,
+        }
+
+    def _build_row(self, row: TimelineRow) -> dict[str, Any]:
+        entry: dict[str, Any] = {
+            "index": row.index,
+            "start": row.start.to_string() if row.start else None,
+            "end": row.end.to_string() if row.end else None,
+            "subtitle": row.subtitle,
+            "telop": None,
+            "packs": row.packs,
+            "objects": [],
+            "fx": [],
+            "notes": row.notes,
+        }
+        if row.start and row.end:
+            entry["duration_seconds"] = max(0.0, row.end.to_seconds() - row.start.to_seconds())
+
+        if row.telop:
+            pattern = self.data.telop_patterns.get(row.telop)
+            if pattern:
+                entry["telop"] = {
+                    "pattern_id": pattern.pattern_id,
+                    "source": pattern.source,
+                    "overrides": pattern.overrides,
+                    "text": row.subtitle,
+                    "scale": 1.0,
+                }
+            else:
+                self._warn(row, f"Telop pattern not found: {row.telop}")
+
+        for obj in row.objects:
+            asset = self.data.assets.get(obj.identifier)
+            if not asset:
+                self._warn(row, f"Asset not found: {obj.identifier}")
+            entry["objects"].append(
+                {
+                    "role": obj.role,
+                    "identifier": obj.identifier,
+                    "layer": obj.layer,
+                    "resolved": asdict(asset) if asset else None,
+                }
+            )
+
+        for fx in row.fxs:
+            preset = self.data.fx_presets.get(fx.fx_id)
+            if not preset:
+                self._warn(row, f"FX preset not found: {fx.fx_id}")
+            entry["fx"].append(
+                {
+                    "fx_id": fx.fx_id,
+                    "parameters": fx.parameters,
+                    "resolved": asdict(preset) if preset else None,
+                }
+            )
+
+        return entry
+
+    def _warn(self, row: TimelineRow, message: str) -> None:
+        self.warnings.append(BuildWarning(row.index, message))
+
+
+def build_project(data: WorkbookData) -> Tuple[dict[str, Any], List[BuildWarning]]:
+    """Generate a project representation and collect warnings."""
+
+    builder = ProjectBuilder(data)
+    project = builder.build()
+    return project, builder.warnings
+
+
+def write_outputs(project: dict[str, Any], warnings: List[BuildWarning], output_dir: str | Path) -> None:
+    """Persist build artefacts to the ``work`` directory."""
+
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    dump_json(output_path / "out.ymmp", project)
+
+    report = {
+        "generated_at": datetime.utcnow().isoformat(timespec="seconds") + "Z",
+        "warning_count": len(warnings),
+        "warnings": [warning.to_dict() for warning in warnings],
+    }
+    dump_json(output_path / "report.json", report)
+
+    history_entry = {
+        "timestamp": datetime.utcnow().isoformat(timespec="seconds") + "Z",
+        "events": [
+            {
+                "row": warning.row_index,
+                "type": "warning",
+                "message": warning.message,
+            }
+            for warning in warnings
+        ],
+    }
+    with open(output_path / "history.jsonl", "a", encoding="utf-8") as fh:
+        fh.write(dump_line(history_entry) + "\n")
+
+
+def dump_line(entry: Dict[str, Any]) -> str:
+    """Serialise a dictionary into a JSON string with UTF-8 characters preserved."""
+
+    import json
+
+    return json.dumps(entry, ensure_ascii=False)
+
+
+def apply_hiragana_shrink(project_path: str | Path, output_path: str | Path, scale: float) -> None:
+    """Apply hiragana shrink filter to a project JSON file."""
+
+    import json
+
+    project_path = Path(project_path)
+    project = json.loads(project_path.read_text(encoding="utf-8"))
+
+    for entry in project.get("timeline", []):
+        telop = entry.get("telop")
+        subtitle = entry.get("subtitle")
+        if not telop:
+            continue
+        if not contains_hiragana(subtitle):
+            continue
+        telop["scale"] = round(float(telop.get("scale", 1.0)) * scale, 4)
+    dump_json(output_path, project)


### PR DESCRIPTION
## Summary
- add a Python package scaffold with Typer-based CLI for sheet generation, project build, filtering, and data absorption
- implement spreadsheet parsers, data models, and YMMP project builder utilities to follow the requirements document
- configure project metadata and ignore compiled artifacts

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68cfcd090a4c832da9af884c94fd0cd3