### PR TITLE
Enhance project builder with packs and FX support

### DIFF
--- a/src/auto_movie_edit/models.py
+++ b/src/auto_movie_edit/models.py
@@ -75,6 +75,8 @@ class TimelineFx:
     """Represents FX applied to a timeline row."""
     fx_id: str
     parameters: Dict[str, Any] = field(default_factory=dict)
+    source_column: Optional[str] = None
+    column_index: Optional[int] = None
     resolved: Optional[FxPreset] = None
 
 @dataclass(slots=True)

--- a/src/auto_movie_edit/workbook.py
+++ b/src/auto_movie_edit/workbook.py
@@ -200,10 +200,18 @@ def load_workbook_data(path: str | Path) -> WorkbookData:
                 total_fx = sum(len(values) for values in fx_values.values())
                 fx_param_raw = _parse_fx_params(r.get("FX_PARAM"))
                 fxs: List[TimelineFx] = []
-                for column, values in fx_values.items():
+                for column_index, column in enumerate(fx_cols):
+                    values = fx_values.get(column, [])
                     for fx_id in values:
                         params = _select_fx_parameters(fx_param_raw, fx_id, column, total_fx)
-                        fxs.append(TimelineFx(fx_id=fx_id, parameters=params))
+                        fxs.append(
+                            TimelineFx(
+                                fx_id=fx_id,
+                                parameters=params,
+                                source_column=column,
+                                column_index=column_index,
+                            )
+                        )
                 notes: Dict[str, Any] = {}
                 if fx_param_raw not in (None, {}):
                     notes["fx_params"] = fx_param_raw


### PR DESCRIPTION
## Summary
- expand the workbook FX ingestion so timeline FX retain their source column metadata
- extend the project builder to clone packs, expand FX presets, control layer bands, and warn for unresolved resources

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d2a465a448832dba705f89cf5518ba