### PR TITLE
Implement schema mapping and history logging

### DIFF
--- a/src/auto_movie_edit/cli.py
+++ b/src/auto_movie_edit/cli.py
@@ -53,8 +53,8 @@ def build(
 ) -> None:
     """Build a simplified YMMP project from the workbook."""
     data = load_workbook_data(sheet)
-    project, warnings = build_project(data)
-    write_outputs(project, warnings, out)
+    project, warnings, history = build_project(data)
+    write_outputs(project, warnings, out, history)
     typer.secho(f"Project generated with {len(warnings)} warnings -> {out}", fg=typer.colors.GREEN)
 
 

--- a/src/auto_movie_edit/models.py
+++ b/src/auto_movie_edit/models.py
@@ -69,6 +69,7 @@ class TimelineObject:
     identifier: str
     layer: Optional[int]
     resolved: Optional[Asset] = None
+    source_column: Optional[str] = None
 
 @dataclass(slots=True)
 class TimelineFx:
@@ -76,8 +77,10 @@ class TimelineFx:
     fx_id: str
     parameters: Dict[str, Any] = field(default_factory=dict)
     source_column: Optional[str] = None
+    source_key: Optional[str] = None
     column_index: Optional[int] = None
     resolved: Optional[FxPreset] = None
+    applied_parameters: Dict[str, Any] = field(default_factory=dict)
 
 @dataclass(slots=True)
 class TimelineRow:
@@ -104,4 +107,5 @@ class WorkbookData:
     characters: Dict[str, Character] = field(default_factory=dict)
     layers: Dict[str, LayerBand] = field(default_factory=dict)
     timeline: List[TimelineRow] = field(default_factory=list)
-    schema_map: Dict[str, Dict[str, str]] = field(default_factory=dict)
+    schema_map: Dict[str, Dict[str, List[str]]] = field(default_factory=dict)
+


### PR DESCRIPTION
## Summary
- load SCHEMA_MAP definitions and use them to resolve sheet columns when parsing workbooks
- enrich timeline models with source metadata and capture FX overrides for validation
- record build history with per-row entries, validate FX parameters, and write history.jsonl files into dated folders

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d3185d7df8832da79222fafe769e20