### PR TITLE
Use copy.deepcopy for deep copy operations

### DIFF
--- a/src/auto_movie_edit/ymmp.py
+++ b/src/auto_movie_edit/ymmp.py
@@ -1,6 +1,7 @@
 """Generation of YMM4-compatible project structures."""
 
 from __future__ import annotations
+import copy
 import json
 from pathlib import Path
 from typing import Any, Dict, List, Set, Tuple
@@ -479,7 +480,7 @@ class ProjectBuilder:
             self._warn(row, f"Unresolved template path{context}: {file_path}")
 
     def _deep_copy(self, data: Any) -> Any:
-        return json.loads(json.dumps(data))
+        return copy.deepcopy(data)
 
     def _warn(self, row: TimelineRow, message: str): self.warnings.append(BuildWarning(row.index, message))
 


### PR DESCRIPTION
## Summary
- replace the JSON round-trip cloning helper with copy.deepcopy so template cloning preserves non-JSON-compatible values

## Testing
- PYTHONPATH=src python - <<'PY'
from pathlib import Path
from auto_movie_edit.ymmp import ProjectBuilder
from auto_movie_edit.models import WorkbookData, TimelineRow

row = TimelineRow(index=0, start=None, end=None, subtitle=None, telop=None)
data = WorkbookData(timeline=[row])
builder = ProjectBuilder(data)

template = {
    "FilePath": Path("dummy"),
    "Nested": {"path": Path("nested")},
}
item = builder._create_item_from_template(template, row)
assert item["FilePath"] == Path("dummy")
assert item["Nested"]["path"] == Path("nested")

template["FilePath"] = Path("modified")
assert item["FilePath"] == Path("dummy")

merged = builder._merge_parameters({"a": Path("foo"), "b": {"c": Path("bar")}}, {"b": {"c": Path("baz")}})
assert merged["a"] == Path("foo")
assert merged["b"]["c"] == Path("baz")
print("ok")
PY
- PYTHONPATH=src python -m auto_movie_edit.cli build --sheet Template/template.xlsx --out work

------
https://chatgpt.com/codex/tasks/task_e_68d392b7c6ac832dafadd110aa85bd6f