### PR TITLE
Enhance tone detection and stabilize tachie rendering

### DIFF
--- a/src/auto_movie_edit/language.py
+++ b/src/auto_movie_edit/language.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from collections import Counter
+from collections import Counter, defaultdict
 from dataclasses import dataclass
+import math
 import re
-from typing import List, Sequence
+from typing import Dict, List, Sequence
 
 try:  # pragma: no cover - optional dependency loading
     from fugashi import Tagger  # type: ignore
@@ -17,6 +18,115 @@ __all__ = ["LanguageAnalyzer", "SubtitleAnalysis", "SubtitleInsight"]
 
 _WORD_PATTERN = re.compile(r"[A-Za-z0-9ぁ-んァ-ヶ一-龯ー]+")
 _PRIMARY_POS = {"名詞", "動詞", "形容詞", "副詞"}
+
+_QUESTION_SUFFIXES = (
+    "か",
+    "かな",
+    "かい",
+    "かしら",
+    "でしょうか",
+    "ですか",
+    "だろうか",
+    "なの",
+)
+
+_TONE_KEYWORD_SCORES: Dict[str, Dict[str, float]] = {
+    "質問調": {
+        "か": 0.4,
+        "かな": 0.8,
+        "かい": 0.8,
+        "かしら": 1.0,
+        "だろうか": 1.1,
+        "でしょうか": 1.3,
+        "ですか": 1.2,
+        "なの": 0.6,
+        "何": 0.5,
+        "どう": 0.5,
+        "なぜ": 0.7,
+    },
+    "強調": {
+        "絶対": 1.5,
+        "本当": 1.1,
+        "ほんと": 1.0,
+        "ほんとう": 1.0,
+        "めっちゃ": 1.3,
+        "超": 1.1,
+        "すごい": 0.9,
+        "すごく": 1.2,
+        "マジ": 1.0,
+        "断言": 1.2,
+        "必ず": 1.2,
+        "最強": 1.1,
+        "重要": 0.9,
+        "強調": 1.0,
+    },
+    "余韻": {
+        "かな": 0.6,
+        "かも": 0.8,
+        "かしら": 0.5,
+        "かなぁ": 1.0,
+        "かなー": 0.8,
+        "かもね": 1.0,
+        "だよね": 0.6,
+        "かもしれ": 1.1,
+        "と思う": 0.7,
+        "気がする": 0.9,
+    },
+    "喜び": {
+        "嬉しい": 2.0,
+        "たのしい": 1.5,
+        "楽しい": 1.5,
+        "最高": 1.4,
+        "やった": 1.6,
+        "よかった": 1.3,
+        "助かる": 1.1,
+        "ありがとう": 1.4,
+        "感謝": 1.2,
+        "幸せ": 1.6,
+    },
+    "悲しみ": {
+        "悲しい": 2.0,
+        "つらい": 1.7,
+        "さみしい": 1.5,
+        "最悪": 1.1,
+        "泣": 1.4,
+        "しんどい": 1.3,
+        "辛い": 1.7,
+        "寂しい": 1.5,
+        "落ち込": 1.6,
+        "ショック": 1.3,
+    },
+    "怒り": {
+        "怒": 1.6,
+        "許せない": 2.0,
+        "ふざけるな": 1.8,
+        "ムカつく": 1.9,
+        "信じられない": 1.4,
+        "なんで": 0.8,
+        "ひどい": 1.3,
+        "納得できない": 1.6,
+    },
+    "驚き": {
+        "えっ": 1.5,
+        "まさか": 1.6,
+        "嘘": 1.3,
+        "ほんと": 1.0,
+        "信じられない": 1.6,
+        "びっくり": 1.7,
+        "驚": 1.5,
+        "なにそれ": 1.4,
+    },
+}
+
+_CATEGORY_PRIORITY = [
+    "強調",
+    "質問調",
+    "喜び",
+    "驚き",
+    "怒り",
+    "悲しみ",
+    "余韻",
+]
 
 
 @dataclass(slots=True)
@@ -134,18 +244,76 @@ class LanguageAnalyzer:
         except Exception as exc:  # pragma: no cover - defensive
             self._tagger_error = exc
 
-    @staticmethod
-    def _detect_emphasis(text: str | None) -> str | None:
+    def _detect_emphasis(self, text: str | None) -> str | None:
         if not text:
             return None
+
         stripped = text.strip()
         if not stripped:
             return None
+
+        normalized_tail = re.sub(r"[\s。．\.！!？?〜ー…]*$", "", stripped)
+        tokens = self.tokenize(stripped)
+        if not tokens:
+            tokens = [token.lower() for token in _WORD_PATTERN.findall(stripped)]
+        counter = Counter(tokens)
+        scores: Dict[str, float] = defaultdict(float)
+
+        # Punctuation based heuristics
         if "？" in stripped or "?" in stripped:
-            return "質問調"
-        if stripped.endswith("！") or stripped.endswith("!"):
-            return "強調"
+            scores["質問調"] += 2.5
+        if stripped.endswith("？") or stripped.endswith("?"):
+            scores["質問調"] += 1.5
+        if "！" in stripped or "!" in stripped:
+            emphasis_boost = 1.2 + 0.3 * (stripped.count("！") + stripped.count("!"))
+            scores["強調"] += emphasis_boost
+            scores["驚き"] += emphasis_boost * 0.3
         if "..." in stripped or "…" in stripped:
-            return "余韻"
-        return None
+            scores["余韻"] += 1.2
+        if stripped.endswith("〜") or stripped.endswith("ー"):
+            scores["余韻"] += 0.8
+        if "！？" in stripped or "?!" in stripped:
+            scores["驚き"] += 1.4
+            scores["強調"] += 0.6
+
+        # Tail-based linguistic cues
+        for suffix in _QUESTION_SUFFIXES:
+            if normalized_tail.endswith(suffix):
+                scores["質問調"] += 0.9 + 0.15 * len(suffix)
+        if normalized_tail.endswith("かな") or normalized_tail.endswith("かも"):
+            scores["余韻"] += 0.6
+
+        # Keyword-based weighting from morphological tokens
+        for token, count in counter.items():
+            for category, keyword_map in _TONE_KEYWORD_SCORES.items():
+                for keyword, weight in keyword_map.items():
+                    if keyword in token:
+                        scores[category] += weight * count
+
+        # Soft sentiment modifier based on positive/negative balance
+        positive = scores.get("喜び", 0.0)
+        negative = scores.get("悲しみ", 0.0) + scores.get("怒り", 0.0)
+        if positive > 0 and positive > negative:
+            scores["喜び"] += math.log1p(positive)
+        if negative > 0:
+            scores["悲しみ"] += math.log1p(scores.get("悲しみ", 0.0)) * 0.5
+            scores["怒り"] += math.log1p(scores.get("怒り", 0.0)) * 0.5
+
+        if not scores:
+            return None
+
+        best_category = max(scores.items(), key=lambda item: item[1])
+        if best_category[1] < 1.0:
+            return None
+
+        # Resolve ties by category priority to keep behaviour deterministic.
+        best_score = best_category[1]
+        tied_categories = [
+            category for category, score in scores.items() if abs(score - best_score) < 0.25
+        ]
+        if len(tied_categories) > 1:
+            for category in _CATEGORY_PRIORITY:
+                if category in tied_categories:
+                    return category
+        return best_category[0]
 


### PR DESCRIPTION
## Summary
- enrich tone detection with morphological scoring, emotion keywords, and tie-breaking logic
- add robust tachie expression resolution with extension flexibility and fallback reuse
- refine hiragana shrink filter to preserve keyframes while sizing for 1080x1920 layouts

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d3a7e16d78832d9fa83e5a24411f04