### PR TITLE
Add tachie resolution cache and tests

### DIFF
--- a/src/auto_movie_edit/ymmp.py
+++ b/src/auto_movie_edit/ymmp.py
@@ -154,6 +154,7 @@ class ProjectBuilder:
         self.expression_presets_by_tone: Dict[str, List[ExpressionPreset]] = {}
         self.default_expression_presets: List[ExpressionPreset] = []
         self._template_cache: Dict[tuple[str, Any], tuple[Mapping[str, Any], Tuple[tuple[str, Any], ...]]] = {}
+        self._tachie_resolution_cache: Dict[tuple[str, str], TachieExpressionResolution] = {}
         for preset in self.data.expression_presets.values():
             if not preset.tones:
                 self.default_expression_presets.append(preset)
@@ -352,7 +353,11 @@ class ProjectBuilder:
                         base_path = char_def.parts.get(part_jp) if char_def else None
                         key = (char_def.name, part_en) if part_en else None
                         if part_en and base_path:
-                            resolution = _resolve_tachie_expression_path(base_path, expr_fn)
+                            cache_key = (base_path, expr_fn)
+                            resolution = self._tachie_resolution_cache.get(cache_key)
+                            if resolution is None:
+                                resolution = _resolve_tachie_expression_path(base_path, expr_fn)
+                                self._tachie_resolution_cache[cache_key] = resolution
                             if resolution.path:
                                 params[part_en] = str(resolution.path)
                                 if key:

--- a/tests/test_tachie_cache.py
+++ b/tests/test_tachie_cache.py
@@ -1,0 +1,99 @@
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from auto_movie_edit.models import Character, TimelineRow, WorkbookData
+from auto_movie_edit.ymmp import ProjectBuilder, _resolve_tachie_expression_path
+
+
+class TachieResolutionCacheTest(unittest.TestCase):
+    def test_cache_usage_and_fallback_preserved(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            base_path = str(Path(tmpdir) / "{expression}.png")
+            happy_path = Path(tmpdir) / "happy.png"
+            happy_path.touch()
+            expected_path = str(happy_path.resolve())
+
+            data = WorkbookData(
+                characters={"ch": Character(name="キャラ", parts={"目": base_path})}
+            )
+            builder = ProjectBuilder(data)
+
+            original_resolve = _resolve_tachie_expression_path
+            call_records: list[tuple[str, str]] = []
+
+            def fake_resolve(path: str, expression: str):
+                call_records.append((path, expression))
+                return original_resolve(path, expression)
+
+            with patch("auto_movie_edit.ymmp._resolve_tachie_expression_path", side_effect=fake_resolve):
+                row1 = TimelineRow(
+                    index=0,
+                    start=None,
+                    end=None,
+                    subtitle=None,
+                    telop=None,
+                    character="ch",
+                    expressions={"目": "happy"},
+                )
+                items1 = builder._build_row_items(row1)
+                self.assertEqual(len(items1), 1)
+                params1 = items1[0]["TachieItemParameter"]
+                self.assertEqual(params1["Eye"], expected_path)
+                self.assertEqual(len(call_records), 1)
+
+                row2 = TimelineRow(
+                    index=1,
+                    start=None,
+                    end=None,
+                    subtitle=None,
+                    telop=None,
+                    character="ch",
+                    expressions={"目": "happy"},
+                )
+                builder._build_row_items(row2)
+                self.assertEqual(len(call_records), 1, "Resolution should be cached for identical expressions")
+
+                row3 = TimelineRow(
+                    index=2,
+                    start=None,
+                    end=None,
+                    subtitle=None,
+                    telop=None,
+                    character="ch",
+                    expressions={"目": "missing"},
+                )
+                items3 = builder._build_row_items(row3)
+                self.assertEqual(len(call_records), 2)
+                params3 = items3[0]["TachieItemParameter"]
+                self.assertEqual(
+                    params3["Eye"],
+                    expected_path,
+                    "Missing expressions should reuse last successful path",
+                )
+
+                row4 = TimelineRow(
+                    index=3,
+                    start=None,
+                    end=None,
+                    subtitle=None,
+                    telop=None,
+                    character="ch",
+                    expressions={"目": "missing"},
+                )
+                items4 = builder._build_row_items(row4)
+                self.assertEqual(
+                    len(call_records),
+                    2,
+                    "Failed resolution should also be cached to avoid repeat lookups",
+                )
+                params4 = items4[0]["TachieItemParameter"]
+                self.assertEqual(params4["Eye"], expected_path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a cache to ProjectBuilder for tachie expression resolutions so repeated lookups reuse the resolved path
- reuse cached results inside _build_row_items while keeping existing last-path fallback warnings intact
- add a unit test that verifies the cache hits for repeated expressions and preserves reuse of the previous path when files are missing

## Testing
- python -m unittest discover -s tests

------
https://chatgpt.com/codex/tasks/task_e_68d3b0efea4c832d818ee520b8869b04